### PR TITLE
Tweak title page

### DIFF
--- a/specification/sbolvisual.tex
+++ b/specification/sbolvisual.tex
@@ -177,12 +177,10 @@ Pedro Fontanarrosa & \emph{University of Utah}\\
 Vishwesh Kulkarni & \emph{University of Warwick}\\
 James McLaughlin & \emph{Newcastle University, UK}\\
 Prasant Vaidyanathan & \emph{Microsoft Research, UK}\\
-\end{tabular}\\
-{\bf Chair:}\hfil\\
-\begin{tabular}{l>{\hspace*{15pt}}r}
+\multicolumn{2}{c}{\href{mailto:sbol-editors@googlegroups.com}{\sffamily sbol-editors@googlegroups.com}}\\
+\multicolumn{2}{c}{ {\bf Chair:} } \\
 Chris Myers & \emph{University of Utah, USA}\\
 \end{tabular}\\
-\href{mailto:editors@sbolstandard.org}{\sffamily editors@sbolstandard.org}\\
 {\bf Additional authors, by last name:}\\
 \begin{small}
 \begin{tabular}{l>{\hspace*{15pt}}r}


### PR DESCRIPTION
- move editors email address
- align name institution columns for the editors and chair sections

Ideally all three sections would be in a single table (as in the SBOL 3 spec) but this would require moving the title up to make more space

Before:
![before](https://user-images.githubusercontent.com/338833/77254346-6a073300-6c58-11ea-9ee2-8f97f44d01e1.png)


After:
![after](https://user-images.githubusercontent.com/338833/77254351-712e4100-6c58-11ea-89a7-f8ec907d40f0.png)

