### PR TITLE
fix error that \warning is already defined

### DIFF
--- a/specification/sbmlpkgspec.cls
+++ b/specification/sbmlpkgspec.cls
@@ -958,7 +958,6 @@ Package Specification Style]
 \reversemarginpar  % Want these be put on the left, not the right.
 
 \newcommand{\notice}{\marginpar{\hspace*{34pt}\raisebox{-0.5ex}{\color{black}\Large\ding{43}}}}
-\newcommand{\warning}{\marginpar{\hspace*{34pt}{\color{red}\large\danger}}}
 
 % Margin notes.
 %


### PR DESCRIPTION
The equivalent change was already made for the main SBOL specification: https://github.com/SynBioDex/SBOL-specification/commit/ac980546906b338e75ad0bb74e3f0249b4523e2a#diff-3ed4205b8ca37ef807a94c617a4a19f4
