### PR TITLE
Improve copyright declaration

### DIFF
--- a/LICENSE.html
+++ b/LICENSE.html
@@ -1,10 +1,14 @@
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/">
+  <img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
+<br />Except as noted below, this work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
 <p xmlns:dct="http://purl.org/dc/terms/" xmlns:vcard="http://www.w3.org/2001/vcard-rdf/3.0#">
   <a rel="license"
      href="http://creativecommons.org/publicdomain/zero/1.0/">
     <img src="http://i.creativecommons.org/p/zero/1.0/88x31.png" style="border-style: none;" alt="CC0" />
   </a>
   <br />
-  To the extent possible under law,
+  Exception: to the extent possible under law,
   <a rel="dct:publisher"
      href="http://www.sbolstandard.org/">
     <span property="dct:title">the SBOL developers</span></a>


### PR DESCRIPTION
Address issue #99: explicitly declare that all the rest of the material outside of the glyphs is available under CC-BY. The glyphs remain CC-0.