### PR TITLE
Tidy SEP metadata

### DIFF
--- a/SEPs/SEP_V001.md
+++ b/SEPs/SEP_V001.md
@@ -1,9 +1,10 @@
 # SEP V001: Bounding box, interior, backbone alignment, and relative scale
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Bounding box, interior, backbone alignment |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V002.md
+++ b/SEPs/SEP_V002.md
@@ -1,14 +1,15 @@
 # SEP V002: Alternative Glyphs
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Alternative Glyphs |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |
 | **Created** | 21-Jul-2017 |
-| **Last modified** | <leave empty if this is the first submission> |
+| **Last modified** |  |
 | **Issue**         | [#5](https://github.com/SynBioDex/SBOL-visual/issues/5) |
 
 ## Abstract

--- a/SEPs/SEP_V003.md
+++ b/SEPs/SEP_V003.md
@@ -1,9 +1,10 @@
 # SEP V003: Distinguished Unknowns
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Distinguished Unknowns |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V004.md
+++ b/SEPs/SEP_V004.md
@@ -1,9 +1,10 @@
 # SEP V004: New Glyph Collection
 
-| SEP | <leave empty> |
+| SEP |  |
 | --- | --- |
+| **Title** | New Glyph Collection |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V005.md
+++ b/SEPs/SEP_V005.md
@@ -1,9 +1,10 @@
 # SEP V005: Ambiguities and Variants
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Ambiguities and Variants |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V006.md
+++ b/SEPs/SEP_V006.md
@@ -1,14 +1,15 @@
 # SEP V006: No Glyph Assigned
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | No Glyph Assigned |
 | **Authors** | Jacob Beal (jakebeal@ieee.org), Chris Myers |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |
 | **Created** | 14-Sep-2017 |
-| **Last modified** | Never |
+| **Last modified** | |
 | **Issue**         | [#11](https://github.com/SynBioDex/SBOL-visual/issues/11) |
 
 ## Abstract

--- a/SEPs/SEP_V007.md
+++ b/SEPs/SEP_V007.md
@@ -1,9 +1,10 @@
 # SEP V007: Stem-Top Glyphs
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Stem-Top Glyphs |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V008.md
+++ b/SEPs/SEP_V008.md
@@ -1,9 +1,10 @@
 # SEP V008: Functional Component Glyphs
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Functional Component Glyphs |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 2.0 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V009.md
+++ b/SEPs/SEP_V009.md
@@ -1,14 +1,15 @@
 # SEP V009: Engineered Region vs. Composite
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Engineered Region vs. Composite |
 | **Authors** | Jacob Beal (jakebeal@ieee.org), Chris Myers, John Sexton |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 1.1 |
 | **Status** | Accepted |
 | **Created** | 7-Oct-2017 |
-| **Last modified** | Never |
+| **Last modified** | |
 | **Issue**       | [#16](https://github.com/SynBioDex/SBOL-visual/issues/16) |
 
 ## Abstract

--- a/SEPs/SEP_V010.md
+++ b/SEPs/SEP_V010.md
@@ -1,9 +1,10 @@
 # SEP V010: Arrows
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Bounding box, interior, backbone alignment |
 | **Authors** | Chris Myers, Anil Wipat, Zachary Palchick, Nicholas Roehner, Bryan Bartley, Ruud Stoof, Jacob Beal |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 2.0 |
 | **Status** | Accepted |

--- a/SEPs/SEP_V011.md
+++ b/SEPs/SEP_V011.md
@@ -1,14 +1,16 @@
 # SEP V011: Genomic Context
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Genomic Context |
 | **Authors** | Angel Goni Moreno, Shyam Bhakta, Jacob Beal, John Sexton, Sebastian Castillo-Hair |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 2.1 |
 | **Status** | Draft |
 | **Created** | 12-Apr-2018 |
 | **Last modified** | 12-Apr-2018 |
+| **Issue** | [#40](https://github.com/SynBioDex/SBOL-visual/issues/40) |
 
 ## Abstract
 

--- a/SEPs/SEP_V012.md
+++ b/SEPs/SEP_V012.md
@@ -1,14 +1,16 @@
 # SEP V012: Transcription and translation end points
 
-| SEP | <leave empty> |
+| SEP | |
 | --- | --- |
+| **Title** | Transcription and translation end points |
 | **Authors** | Thomas Gorochowski, John Sexton, Jacob Beal |
-| **Editor** | <leave empty> |
+| **Editor** | |
 | **Type** | Specification |
 | **SBOL Visual Version** | 2.1 |
 | **Status** | Draft |
 | **Created** | 07-Apr-2018 |
 | **Last modified** | 19-Apr-2018 |
+| **Issue** | [#41](https://github.com/SynBioDex/SBOL-visual/issues/41) |
 
 ## Abstract
 

--- a/SEPs/SEP_V013.md
+++ b/SEPs/SEP_V013.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Multi-source and multi-target arrows |
 | **Authors** | Thomas Gorochowski, Jacob Beal |
 | **Editor** |  |
 | **Type** | Specification |
@@ -9,7 +10,7 @@
 | **Status** | Draft |
 | **Created** | 23-Aug-2018 |
 | **Last modified** | 4-Nov-2018 |
-| **Issue**         | [#47](https://github.com/SynBioDex/SBOL-visual/issues/47) |
+| **Issue** | [#47](https://github.com/SynBioDex/SBOL-visual/issues/47) |
 
 ## Abstract
 

--- a/SEPs/SEP_V014.md
+++ b/SEPs/SEP_V014.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Modules and MapsTo |
 | **Authors** | James Scott-Brown (james@jamesscottbrown.com), Jacob Beal |
 | **Editor** |  |
 | **Type** | Specification |

--- a/SEPs/SEP_V015.md
+++ b/SEPs/SEP_V015.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Change BioPAX to SBO |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
 | **Editor** | Zach Palchick |
 | **Type** | Specification |

--- a/SEPs/SEP_V016.md
+++ b/SEPs/SEP_V016.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Introns and Polypeptide Regions |
 | **Authors** | Jacob Beal (jakebeal@ieee.org), Marta Vázquez Vilar (marvazvi@ibmcp.upv.es) |
 | **Editor** |  | Hasan Baig
 | **Type** | Specification |

--- a/SEPs/SEP_V017.md
+++ b/SEPs/SEP_V017.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Protein, Macromolecule, and Alternative Simple Chemicals |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
 | **Editor** | Zach Palchick |
 | **Type** | Specification |

--- a/SEPs/SEP_V018.md
+++ b/SEPs/SEP_V018.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Interactions with Interaction Nodes |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
 | **Editor** | TBD |
 | **Type** | Specification |

--- a/SEPs/SEP_V019.md
+++ b/SEPs/SEP_V019.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Allow Complex to Include DNA Backbone |
 | **Authors** | Jacob Beal (jakebeal@ieee.org), John Sexton |
 | **Editor** | TBD |
 | **Type** | Specification |

--- a/SEPs/SEP_V020.md
+++ b/SEPs/SEP_V020.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Recommend use of polypeptide region for 2A Sequences |
 | **Authors** | Jacob Beal (jakebeal@ieee.org), Shyam Bhakta |
 | **Editor** | TBD |
 | **Type** | Specification |

--- a/SEPs/SEP_V021.md
+++ b/SEPs/SEP_V021.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Unspecified Interaction Glyph Node |
 | **Authors** | Logan Terry |
 | **Editor** | TBD |
 | **Type** | Specification |

--- a/SEPs/SEP_V022.md
+++ b/SEPs/SEP_V022.md
@@ -2,6 +2,7 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | Inert DNA spacer |
 | **Authors** | Jacob Beal (jakebeal@ieee.org), Shyam Bhakta, John Sexton |
 | **Editor** | TBD |
 | **Type** | Specification |

--- a/SEPs/SEP_V023.md
+++ b/SEPs/SEP_V023.md
@@ -2,13 +2,14 @@
 
 | SEP | |
 | --- | --- |
+| **Title** | SBOL Visual specification change workflow |
 | **Authors** | Jacob Beal (jakebeal@ieee.org) |
 | **Editor** | TBD |
 | **Type** | Process |
 | **Status** | Draft |
 | **Created** | 9-Oct-2020 |
 | **Last modified** | 23-Nov-2020 |
-| **Issue**         | TBD |
+| **Issue** | [#109](https://github.com/SynBioDex/SBOL-visual/issues/109) |
 
 
 ## Abstract


### PR DESCRIPTION
- add title field
- enure every SEP links to corresponding GitHub Issue
- remove '<Leave Blank>' messages

These changes result in the automatically generated summary table being more useful.